### PR TITLE
Fix: Ignore 'Info: ingnoring crashdata' while trying to get the emula…

### DIFF
--- a/install_hosts_to_emulator.sh
+++ b/install_hosts_to_emulator.sh
@@ -10,7 +10,7 @@ Para poder ejecutar este script es necesario que no haya ningún emulador arranc
 fi
 
 # Listamos los emuladores disponibles y pedimos al usuario que seleccione uno
-emuladores=$(emulator -list-avds)
+emuladores=$(emulator -list-avds | grep -v '^INFO' | grep -v '^Storing')
 echo "Emuladores disponibles:\n"
 i=1
 for emulador in $emuladores

--- a/run_emulator.sh
+++ b/run_emulator.sh
@@ -1,5 +1,5 @@
 # Listamos los emuladores disponibles y pedimos al usuario que seleccione uno
-emuladores=$(emulator -list-avds)
+emuladores=$(emulator -list-avds | grep -v '^INFO' | grep -v '^Storing' | grep -v '^crashdata')
 echo "Emuladores disponibles:\n"
 i=1
 for emulador in $emuladores


### PR DESCRIPTION
my emulator --list-avds returns

```
emulator -list-avds
INFO    | Storing crashdata in: /tmp/android-jesusyepes/emu-crash-34.2.15.db, detection is enabled for process: 35426
Nexus_One_API_28_android_9
Pixel_3a_API_34
Pixel_4a_API_32
Pixel_5_API_26
Pixel_5_API_31
Pixel_7_API_33
```

which breaks the parsing logic to display the available emulators